### PR TITLE
Correct definition of header guard.

### DIFF
--- a/src/libzling_inc.h
+++ b/src/libzling_inc.h
@@ -33,7 +33,7 @@
  * @brief  include headers.
  */
 #ifndef SRC_LIBZLING_INC_H
-#define SRC_INC_H
+#define SRC_LIBZLING_INC_H
 
 #include <algorithm>
 #include <cstdio>


### PR DESCRIPTION
Current code checks for SRC_LIBZLING_INC_H but defines SRC_INC_H
