### PR TITLE
Don't access memory outside the supplied buffers when decoding

### DIFF
--- a/src/libzling_lz.cpp
+++ b/src/libzling_lz.cpp
@@ -84,12 +84,7 @@ static inline void IncrementalCopyFastPath(unsigned char* src, unsigned char* ds
         len -= dst - src;
         dst += dst - src;
     }
-    while (len > 0) {
-        *reinterpret_cast<volatile uint32_t*>(dst) = *reinterpret_cast<volatile uint32_t*>(src);
-        len -= 4;
-        dst += 4;
-        src += 4;
-    }
+    memmove(dst, src, len);
     return;
 }
 


### PR DESCRIPTION
The old code would overshoot the supplied buffer by as much as 3 bytes,
which could cause crashes in some situations.

https://github.com/richox/libzling/issues/6
