### PR TITLE
Add squash MSVC support

### DIFF
--- a/demo/zling.cpp
+++ b/demo/zling.cpp
@@ -39,7 +39,7 @@
 
 #define __STDC_FORMAT_MACROS
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && _MSC_VER < 1600
 #include "msinttypes/stdint.h"
 #include "msinttypes/inttypes.h"
 

--- a/src/libzling_inc.h
+++ b/src/libzling_inc.h
@@ -41,7 +41,7 @@
 #include <cstring>
 #include <stdexcept>
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && _MSC_VER < 1600
 #include "msinttypes/stdint.h"
 #include "msinttypes/inttypes.h"
 

--- a/src/libzling_lz.cpp
+++ b/src/libzling_lz.cpp
@@ -43,8 +43,10 @@ static const unsigned char mtfnext[] = {
 #   include "ztable_mtfnext.inc"  /* include auto-generated constant tables */
 };
 
+#ifdef __GNUC__
 static inline uint32_t RollingAdd(uint32_t x, uint32_t y) __attribute__((pure));
 static inline uint32_t RollingSub(uint32_t x, uint32_t y) __attribute__((pure));
+#endif
 
 static inline uint32_t HashContext(unsigned char* ptr) {
     return (*reinterpret_cast<uint32_t*>(ptr) + ptr[2] * 137 + ptr[3] * 13337);


### PR DESCRIPTION
A few changes to allow the squash zling plugin to compile with MSVC. See quixdb/squash#145.

Should also fix #3.

I am still getting an exception on decompressing, but I think having it compile is a step in the right direction.
